### PR TITLE
Explicitly set new_browser_tab=false

### DIFF
--- a/plutoserver/__init__.py
+++ b/plutoserver/__init__.py
@@ -6,6 +6,7 @@ def setup_plutoserver():
   return {
     "command": ["julia", "--optimize=0", "-e", "import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
     "timeout": 60,
+    "new_browser_tab": False,
     "launcher_entry": {
         "title": "Pluto.jl",
         "icon_path": iconpath


### PR DESCRIPTION
This has the advantage that new Pluto tabs are opened as a tab inside of JupyterLab's window, which allows users to have access to Jupyter's various tools (Text editors, etc) in the same tab as Pluto.